### PR TITLE
Fix trailing line for package.el compatibility

### DIFF
--- a/es-auto-auto-indent.el
+++ b/es-auto-auto-indent.el
@@ -369,4 +369,4 @@ if the mode indents well in all but a few cases, you can change the
 (defvaralias 'es-aai-mode 'es-auto-auto-indent-mode)
 
 (provide 'es-auto-auto-indent)
-;; es-auto-auto-indent.el ends here
+;;; es-auto-auto-indent.el ends here


### PR DESCRIPTION
The trailing line requires 3 leading semicolons in order to be parsed by `package-buffer-info`. Without this fix, the file cannot be installed from the automatically-built packages on [MELPA](http://melpa.milkbox.net).
